### PR TITLE
wiki replacement

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -62,105 +62,105 @@
 		</div>
 		<div class="row">
 			<div class="column">
-				<h2><a href="https://hollowknight.fandom.com/wiki/Category:Bosses_(Hollow_Knight)">Bosses</a></h2>
+				<h2><a href="https://hollowknight.wiki/w/Category:Bosses_(Hollow_Knight)">Bosses</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_1">
 				<input type="checkbox" name="progress" id="item_1" data-key="1" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Broken_Vessel">Broken Vessel</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Broken_Vessel">Broken Vessel</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_2">
 				<input type="checkbox" name="progress" id="item_2" data-key="2" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Brooding_Mawlek">Brooding Mawlek</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Brooding_Mawlek">Brooding Mawlek</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_3">
 				<input type="checkbox" name="progress" id="item_3" data-key="3" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Collector">The Collector</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Collector">The Collector</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_4">
 				<input type="checkbox" name="progress" id="item_4" data-key="4" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dung_Defender">Dung Defender</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dung_Defender">Dung Defender</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_5">
 				<input type="checkbox" name="progress" id="item_5" data-key="5" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/False_Knight">False Knight</a></span>
+			    <span><a href="https://hollowknight.wiki/w/False_Knight">False Knight</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_6">
 				<input type="checkbox" name="progress" id="item_6" data-key="6" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Grimm">Grimm</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Grimm">Grimm</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_7">
 				<input type="checkbox" name="progress" id="item_7" data-key="7" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Gruz_Mother">Gruz Mother</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Gruz_Mother">Gruz Mother</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_8">
 				<input type="checkbox" name="progress" id="item_8" data-key="8" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Hive_Knight">Hive Knight</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Hive_Knight">Hive Knight</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_9">
 				<input type="checkbox" name="progress" id="item_9" data-key="9" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Hornet_Protector">Hornet (Greenpath)</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Hornet_Protector">Hornet (Greenpath)</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_10">
 				<input type="checkbox" name="progress" id="item_10" data-key="10" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Hornet_Sentinel">Hornet (Cast-Off Shell)</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Hornet_Sentinel">Hornet (Cast-Off Shell)</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_11">
 				<input type="checkbox" name="progress" id="item_11" data-key="11" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Mantis_Lords">Mantis Lords</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Mantis_Lords">Mantis Lords</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_12">
 				<input type="checkbox" name="progress" id="item_12" data-key="12" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Nosk">Nosk</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Nosk">Nosk</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_13">
 				<input type="checkbox" name="progress" id="item_13" data-key="13" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Soul_Master">Soul Master</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Soul_Master">Soul Master</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_14">
 				<input type="checkbox" name="progress" id="item_14" data-key="14" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Traitor_Lord">Traitor Lord</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Traitor_Lord">Traitor Lord</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_15">
 				<input type="checkbox" name="progress" id="item_15" data-key="15" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Uumuu">Uumuu</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Uumuu">Uumuu</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_16">
 				<input type="checkbox" name="progress" id="item_16" data-key="16" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Watcher_Knight">Watcher Knight</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Watcher_Knight">Watcher Knight</a></span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Dream_Nail">Dream Nail</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Dream_Nail">Dream Nail</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_30">
@@ -180,7 +180,7 @@
 			    <span>Hear the Seer's final words (<img src="img/icon-essence.png" alt="Essence" class="icon"> 2400)</span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Nail">Nail</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Nail">Nail</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_33">
@@ -206,266 +206,266 @@
 			    <span>Pure Nail (<img src="img/icon-geo.png" alt="Geo" class="icon"> 4000 and <img src="img/icon-pale-ore.png" alt="Pale Ore" class="icon"> 3)</span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Category%3ASpells_and_Abilities_(Hollow_Knight)#Nail_Arts">Nail Arts</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Category%3ASpells_and_Abilities_(Hollow_Knight)#Nail_Arts">Nail Arts</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_37">
 				<input type="checkbox" name="progress" id="item_37" data-key="37" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Great_Slash">Great Slash</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Great_Slash">Great Slash</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_38">
 				<input type="checkbox" name="progress" id="item_38" data-key="38" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dash_Slash">Dash Slash</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dash_Slash">Dash Slash</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_39">
 				<input type="checkbox" name="progress" id="item_39" data-key="39" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Cyclone_Slash">Cyclone Slash</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Cyclone_Slash">Cyclone Slash</a></span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Category:Charms">Charms</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Category:Charms">Charms</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_65">
 				<input type="checkbox" name="progress" id="item_65" data-key="65" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Wayward_Compass">Wayward Compass</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Wayward_Compass">Wayward Compass</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_66">
 				<input type="checkbox" name="progress" id="item_66" data-key="66" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Gathering_Swarm">Gathering Swarm</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Gathering_Swarm">Gathering Swarm</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_67">
 				<input type="checkbox" name="progress" id="item_67" data-key="67" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Stalwart_Shell">Stalwart Shell</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Stalwart_Shell">Stalwart Shell</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_68">
 				<input type="checkbox" name="progress" id="item_68" data-key="68" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Soul_Catcher">Soul Catcher</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Soul_Catcher">Soul Catcher</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_69">
 				<input type="checkbox" name="progress" id="item_69" data-key="69" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Shaman_Stone">Shaman Stone</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Shaman_Stone">Shaman Stone</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_70">
 				<input type="checkbox" name="progress" id="item_70" data-key="70" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Soul_Eater">Soul Eater</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Soul_Eater">Soul Eater</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_71">
 				<input type="checkbox" name="progress" id="item_71" data-key="71" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dashmaster">Dashmaster</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dashmaster">Dashmaster</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_72">
 				<input type="checkbox" name="progress" id="item_72" data-key="72" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Sprintmaster">Sprintmaster</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Sprintmaster">Sprintmaster</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_73">
 				<input type="checkbox" name="progress" id="item_73" data-key="73" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Grubsong">Grubsong</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Grubsong">Grubsong</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_74">
 				<input type="checkbox" name="progress" id="item_74" data-key="74" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Grubberfly's_Elegy">Grubberfly's Elegy</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Grubberfly's_Elegy">Grubberfly's Elegy</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_75">
 				<input type="checkbox" name="progress" id="item_75" data-key="75" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Fragile_Heart">Fragile Heart</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Fragile_Heart">Fragile Heart</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_76">
 				<input type="checkbox" name="progress" id="item_76" data-key="76" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Fragile_Greed">Fragile Greed</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Fragile_Greed">Fragile Greed</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_77">
 				<input type="checkbox" name="progress" id="item_77" data-key="77" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Fragile_Strength">Fragile Strength</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Fragile_Strength">Fragile Strength</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_78">
 				<input type="checkbox" name="progress" id="item_78" data-key="78" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Spell_Twister">Spell Twister</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Spell_Twister">Spell Twister</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_79">
 				<input type="checkbox" name="progress" id="item_79" data-key="79" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Steady_Body">Steady Body</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Steady_Body">Steady Body</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_80">
 				<input type="checkbox" name="progress" id="item_80" data-key="80" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Heavy_Blow">Heavy Blow</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Heavy_Blow">Heavy Blow</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_81">
 				<input type="checkbox" name="progress" id="item_81" data-key="81" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Quick_Slash">Quick Slash</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Quick_Slash">Quick Slash</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_82">
 				<input type="checkbox" name="progress" id="item_82" data-key="82" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Longnail">Longnail</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Longnail">Longnail</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_83">
 				<input type="checkbox" name="progress" id="item_83" data-key="83" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Mark_of_Pride">Mark of Pride</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Mark_of_Pride">Mark of Pride</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_84">
 				<input type="checkbox" name="progress" id="item_84" data-key="84" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Fury_of_the_Fallen">Fury of the Fallen</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Fury_of_the_Fallen">Fury of the Fallen</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_85">
 				<input type="checkbox" name="progress" id="item_85" data-key="85" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Thorns_of_Agony">Thorns of Agony</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Thorns_of_Agony">Thorns of Agony</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_86">
 				<input type="checkbox" name="progress" id="item_86" data-key="86" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Baldur_Shell">Baldur Shell</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Baldur_Shell">Baldur Shell</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_87">
 				<input type="checkbox" name="progress" id="item_87" data-key="87" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Flukenest">Flukenest</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Flukenest">Flukenest</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_88">
 				<input type="checkbox" name="progress" id="item_88" data-key="88" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Defender's_Crest">Defender's Crest</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Defender's_Crest">Defender's Crest</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_89">
 				<input type="checkbox" name="progress" id="item_89" data-key="89" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Glowing_Womb">Glowing Womb</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Glowing_Womb">Glowing Womb</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_90">
 				<input type="checkbox" name="progress" id="item_90" data-key="90" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Quick_Focus">Quick Focus</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Quick_Focus">Quick Focus</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_91">
 				<input type="checkbox" name="progress" id="item_91" data-key="91" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Deep_Focus">Deep Focus</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Deep_Focus">Deep Focus</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_92">
 				<input type="checkbox" name="progress" id="item_92" data-key="92" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Lifeblood_Heart">Lifeblood Heart</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Lifeblood_Heart">Lifeblood Heart</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_93">
 				<input type="checkbox" name="progress" id="item_93" data-key="93" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Lifeblood_Core">Lifeblood Core</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Lifeblood_Core">Lifeblood Core</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_94">
 				<input type="checkbox" name="progress" id="item_94" data-key="94" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Joni's_Blessing">Joni's Blessing</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Joni's_Blessing">Joni's Blessing</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_95">
 				<input type="checkbox" name="progress" id="item_95" data-key="95" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Hiveblood">Hiveblood</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Hiveblood">Hiveblood</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_96">
 				<input type="checkbox" name="progress" id="item_96" data-key="96" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Spore_Shroom">Spore Shroom</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Spore_Shroom">Spore Shroom</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_97">
 				<input type="checkbox" name="progress" id="item_97" data-key="97" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Sharp_Shadow">Sharp Shadow</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Sharp_Shadow">Sharp Shadow</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_98">
 				<input type="checkbox" name="progress" id="item_98" data-key="98" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Shape_of_Unn">Shape of Unn</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Shape_of_Unn">Shape of Unn</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_99">
 				<input type="checkbox" name="progress" id="item_99" data-key="99" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Nailmaster's_Glory">Nailmaster's Glory</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Nailmaster's_Glory">Nailmaster's Glory</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_100">
 				<input type="checkbox" name="progress" id="item_100" data-key="100" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Weaversong">Weaversong</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Weaversong">Weaversong</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_101">
 				<input type="checkbox" name="progress" id="item_101" data-key="101" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dream_Wielder">Dream Wielder</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dream_Wielder">Dream Wielder</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_102">
 				<input type="checkbox" name="progress" id="item_102" data-key="102" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dreamshield">Dreamshield</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dreamshield">Dreamshield</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_103">
 				<input type="checkbox" name="progress" id="item_103" data-key="103" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Grimmchild">Grimmchild</a> / <a href="https://hollowknight.fandom.com/wiki/Carefree_Melody">Carefree Melody</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Grimmchild">Grimmchild</a> / <a href="https://hollowknight.wiki/w/Carefree_Melody">Carefree Melody</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_104">
 				<input type="checkbox" name="progress" id="item_104" data-key="104" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Kingsoul">Kingsoul</a> / <a href="https://hollowknight.fandom.com/wiki/Void_Heart">Void Heart</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Kingsoul">Kingsoul</a> / <a href="https://hollowknight.wiki/w/Void_Heart">Void Heart</a></span>
 			</label>
 		</li>
 	</ul>			</div>
@@ -475,238 +475,238 @@
 			<li>
 			<label class="checkboxLabel" for="item_17">
 				<input type="checkbox" name="progress" id="item_17" data-key="17" data-percent="2">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Mothwing_Cloak">Mothwing Cloak</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Mothwing_Cloak">Mothwing Cloak</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_18">
 				<input type="checkbox" name="progress" id="item_18" data-key="18" data-percent="2">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Mantis_Claw">Mantis Claw</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Mantis_Claw">Mantis Claw</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_19">
 				<input type="checkbox" name="progress" id="item_19" data-key="19" data-percent="2">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Crystal_Heart">Crystal Heart</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Crystal_Heart">Crystal Heart</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_20">
 				<input type="checkbox" name="progress" id="item_20" data-key="20" data-percent="2">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Isma's_Tear">Isma's Tear</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Isma's_Tear">Isma's Tear</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_21">
 				<input type="checkbox" name="progress" id="item_21" data-key="21" data-percent="2">
-			    <span><a href="https://hollowknight.fandom.com/wiki/King's_Brand">King's Brand</a></span>
+			    <span><a href="https://hollowknight.wiki/w/King's_Brand">King's Brand</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_22">
 				<input type="checkbox" name="progress" id="item_22" data-key="22" data-percent="2">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Monarch_Wings">Monarch Wings</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Monarch_Wings">Monarch Wings</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_23">
 				<input type="checkbox" name="progress" id="item_23" data-key="23" data-percent="2">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Shade_Cloak">Shade Cloak</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Shade_Cloak">Shade Cloak</a></span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Category:Spells_and_Abilities_(Hollow_Knight)#Spells">Spells</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Category:Spells_and_Abilities_(Hollow_Knight)#Spells">Spells</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_24">
 				<input type="checkbox" name="progress" id="item_24" data-key="24" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Vengeful_Spirit">Vengeful Spirit</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Vengeful_Spirit">Vengeful Spirit</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_25">
 				<input type="checkbox" name="progress" id="item_25" data-key="25" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Shade_Soul">Shade Soul</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Shade_Soul">Shade Soul</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_26">
 				<input type="checkbox" name="progress" id="item_26" data-key="26" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Desolate_Dive">Desolate Dive</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Desolate_Dive">Desolate Dive</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_27">
 				<input type="checkbox" name="progress" id="item_27" data-key="27" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Descending_Dark">Descending Dark</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Descending_Dark">Descending Dark</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_28">
 				<input type="checkbox" name="progress" id="item_28" data-key="28" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Howling_Wraiths">Howling Wraiths</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Howling_Wraiths">Howling Wraiths</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_29">
 				<input type="checkbox" name="progress" id="item_29" data-key="29" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Abyss_Shriek">Abyss Shriek</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Abyss_Shriek">Abyss Shriek</a></span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Mask_Shard">Mask Shards</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Mask_Shard">Mask Shards</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_49">
 				<input type="checkbox" id="item_49" data-key="49" data-percent="0.25">
-			    <span>Bought from <a href="https://hollowknight.fandom.com/wiki/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">150</span>
+			    <span>Bought from <a href="https://hollowknight.wiki/w/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">150</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_50">
 				<input type="checkbox" id="item_50" data-key="50" data-percent="0.25">
-			    <span>Bought from <a href="https://hollowknight.fandom.com/wiki/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">500</span>
+			    <span>Bought from <a href="https://hollowknight.wiki/w/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">500</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_51">
 				<input type="checkbox" id="item_51" data-key="51" data-percent="0.25">
-			    <span>Bought from <a href="https://hollowknight.fandom.com/wiki/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">800</span>
+			    <span>Bought from <a href="https://hollowknight.wiki/w/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">800</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_52">
 				<input type="checkbox" id="item_52" data-key="52" data-percent="0.25">
-			    <span>Bought from <a href="https://hollowknight.fandom.com/wiki/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">1500</span>
+			    <span>Bought from <a href="https://hollowknight.wiki/w/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">1500</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_53">
 				<input type="checkbox" id="item_53" data-key="53" data-percent="0.25">
-			    <span>Defeating <a href="https://hollowknight.fandom.com/wiki/Brooding_Mawlek">Brooding Mawleck</a> far West of the <a href="https://hollowknight.fandom.com/wiki/Forgotten_Crossroads">Forgotten Crossroads</a></span>
+			    <span>Defeating <a href="https://hollowknight.wiki/w/Brooding_Mawlek">Brooding Mawleck</a> far West of the <a href="https://hollowknight.wiki/w/Forgotten_Crossroads">Forgotten Crossroads</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_54">
 				<input type="checkbox" id="item_54" data-key="54" data-percent="0.25">
-			    <span>Given by <a href="https://hollowknight.fandom.com/wiki/Grubfather">Grubfather</a> after rescuing 5 grubs</span>
+			    <span>Given by <a href="https://hollowknight.wiki/w/Grubfather">Grubfather</a> after rescuing 5 grubs</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_55">
 				<input type="checkbox" id="item_55" data-key="55" data-percent="0.25">
-			    <span> <a href="https://hollowknight.fandom.com/wiki/Forgotten_Crossroads">Forgotten Crossroads</a> South of <a href="https://hollowknight.fandom.com/wiki/False_Knight">False Knight</a> (where there are <a href="https://hollowknight.fandom.com/wiki/Goam">Goams</a>)</span>
+			    <span> <a href="https://hollowknight.wiki/w/Forgotten_Crossroads">Forgotten Crossroads</a> South of <a href="https://hollowknight.wiki/w/False_Knight">False Knight</a> (where there are <a href="https://hollowknight.wiki/w/Goam">Goams</a>)</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_56">
 				<input type="checkbox" id="item_56" data-key="56" data-percent="0.25">
-			    <span>In <a href="https://hollowknight.fandom.com/wiki/Fungal_Wastes#Sub-area:_Queen.27s_Station_.C2.A0">Queen's Station</a>, near East side</span>
+			    <span>In <a href="https://hollowknight.wiki/w/Fungal_Wastes#Sub-area:_Queen.27s_Station_.C2.A0">Queen's Station</a>, near East side</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_57">
 				<input type="checkbox" id="item_57" data-key="57" data-percent="0.25">
-			    <span>Found in <a href="https://hollowknight.fandom.com/wiki/Bretta">Bretta</a>'s house in Dirtmouth</span>
+			    <span>Found in <a href="https://hollowknight.wiki/w/Bretta">Bretta</a>'s house in Dirtmouth</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_58">
 				<input type="checkbox" id="item_58" data-key="58" data-percent="0.25">
-			    <span>Found in <a href="https://hollowknight.fandom.com/wiki/Greenpath#Sub-area:_Stone_Sanctuary">Stone Sanctuary</a> in <a href="https://hollowknight.fandom.com/wiki/Greenpath">Greenpath</a></span>
+			    <span>Found in <a href="https://hollowknight.wiki/w/Greenpath#Sub-area:_Stone_Sanctuary">Stone Sanctuary</a> in <a href="https://hollowknight.wiki/w/Greenpath">Greenpath</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_59">
 				<input type="checkbox" id="item_59" data-key="59" data-percent="0.25">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Royal_Waterways">Royal Waterways</a> NW section, swim left under main path</span>
+			    <span><a href="https://hollowknight.wiki/w/Royal_Waterways">Royal Waterways</a> NW section, swim left under main path</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_60">
 				<input type="checkbox" id="item_60" data-key="60" data-percent="0.25">
-			    <span>Found in <a href="https://hollowknight.fandom.com/wiki/Deepnest">Deepnest</a> through <a href="https://hollowknight.fandom.com/wiki/Fungal_Wastes#Sub-area:_Fungal_Core">Fungal Core</a>, near <a href="https://hollowknight.fandom.com/wiki/Mantis_Lords">Mantis Lords</a></span>
+			    <span>Found in <a href="https://hollowknight.wiki/w/Deepnest">Deepnest</a> through <a href="https://hollowknight.wiki/w/Fungal_Wastes#Sub-area:_Fungal_Core">Fungal Core</a>, near <a href="https://hollowknight.wiki/w/Mantis_Lords">Mantis Lords</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_61">
 				<input type="checkbox" id="item_61" data-key="61" data-percent="0.25">
-			    <span>Reward from <a href="https://hollowknight.fandom.com/wiki/Enraged_Guardian">Enraged Guardian</a></span>
+			    <span>Reward from <a href="https://hollowknight.wiki/w/Enraged_Guardian">Enraged Guardian</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_62">
 				<input type="checkbox" id="item_62" data-key="62" data-percent="0.25">
-			    <span>Found behind a wall in <a href="https://hollowknight.fandom.com/wiki/Hive">The Hive</a></span>
+			    <span>Found behind a wall in <a href="https://hollowknight.wiki/w/Hive">The Hive</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_63">
 				<input type="checkbox" id="item_63" data-key="63" data-percent="0.25">
-			    <span>Given by the <a href="https://hollowknight.fandom.com/wiki/Seer">Seer</a> for <img src="img/icon-essence.png" alt="Essence" class="icon">1500</span>
+			    <span>Given by the <a href="https://hollowknight.wiki/w/Seer">Seer</a> for <img src="img/icon-essence.png" alt="Essence" class="icon">1500</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_64">
 				<input type="checkbox" id="item_64" data-key="64" data-percent="0.25">
-			    <span>Given by <a href="https://hollowknight.fandom.com/wiki/Grey_Mourner">Grey Mourner</a> in <a href="https://hollowknight.fandom.com/wiki/Resting_Grounds">Resting Grounds</a></span>
+			    <span>Given by <a href="https://hollowknight.wiki/w/Grey_Mourner">Grey Mourner</a> in <a href="https://hollowknight.wiki/w/Resting_Grounds">Resting Grounds</a></span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Vessel_Fragment">Vessel Fragments</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Vessel_Fragment">Vessel Fragments</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_40">
 				<input type="checkbox" id="item_40" data-key="40" data-percent="0.3333333">
-			    <span>Bought from <a href="https://hollowknight.fandom.com/wiki/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">550</span>
+			    <span>Bought from <a href="https://hollowknight.wiki/w/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">550</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_41">
 				<input type="checkbox" id="item_41" data-key="41" data-percent="0.3333333">
-			    <span>Bought from <a href="https://hollowknight.fandom.com/wiki/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">900</span>
+			    <span>Bought from <a href="https://hollowknight.wiki/w/Sly">Sly</a> in Dirtmouth for <img src="img/icon-geo.png" alt="Geo" class="icon">900</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_42">
 				<input type="checkbox" id="item_42" data-key="42" data-percent="0.3333333">
-			    <span>Found in <a href="https://hollowknight.fandom.com/wiki/Greenpath">Greenpath</a> near the inaccessible <a href="https://hollowknight.fandom.com/wiki/Queen%27s_Gardens">Queen's Gardens</a> entrance</span>
+			    <span>Found in <a href="https://hollowknight.wiki/w/Greenpath">Greenpath</a> near the inaccessible <a href="https://hollowknight.wiki/w/Queen%27s_Gardens">Queen's Gardens</a> entrance</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_43">
 				<input type="checkbox" id="item_43" data-key="43" data-percent="0.3333333">
-			    <span>Left of the lift in <a href="https://hollowknight.fandom.com/wiki/Forgotten_Crossroads">Forgotten Crossroads</a></span>
+			    <span>Left of the lift in <a href="https://hollowknight.wiki/w/Forgotten_Crossroads">Forgotten Crossroads</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_44">
 				<input type="checkbox" id="item_44" data-key="44" data-percent="0.3333333">
-			    <span>Found above <a href="https://hollowknight.fandom.com/wiki/City_of_Tears#Sub-area:_King.27s_Station">King's Station</a> near a lift</span>
+			    <span>Found above <a href="https://hollowknight.wiki/w/City_of_Tears#Sub-area:_King.27s_Station">King's Station</a> near a lift</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_45">
 				<input type="checkbox" id="item_45" data-key="45" data-percent="0.3333333">
-			    <span>Found in <a href="https://hollowknight.fandom.com/wiki/Deepnest">Deepnest</a> above the working tram</span>
+			    <span>Found in <a href="https://hollowknight.wiki/w/Deepnest">Deepnest</a> above the working tram</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_46">
 				<input type="checkbox" id="item_46" data-key="46" data-percent="0.3333333">
-			    <span>Found at the end of <a href="https://hollowknight.fandom.com/wiki/Howling_Cliffs#Sub-area:_Stag_Nest">Stag Nest</a></span>
+			    <span>Found at the end of <a href="https://hollowknight.wiki/w/Howling_Cliffs#Sub-area:_Stag_Nest">Stag Nest</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_47">
 				<input type="checkbox" id="item_47" data-key="47" data-percent="0.3333333">
-			    <span>Given by the <a href="https://hollowknight.fandom.com/wiki/Seer">Seer</a> for <img src="img/icon-essence.png" alt="Essence" class="icon">700</span>
+			    <span>Given by the <a href="https://hollowknight.wiki/w/Seer">Seer</a> for <img src="img/icon-essence.png" alt="Essence" class="icon">700</span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_48">
 				<input type="checkbox" id="item_48" data-key="48" data-percent="0.3333333">
-			    <span>Found in the fountain in <a href="https://hollowknight.fandom.com/wiki/Ancient_Basin">Ancient Basin</a> for <img src="img/icon-geo.png" alt="Geo" class="icon">3000</span>
+			    <span>Found in the fountain in <a href="https://hollowknight.wiki/w/Ancient_Basin">Ancient Basin</a> for <img src="img/icon-geo.png" alt="Geo" class="icon">3000</span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Colosseum_of_Fools">Colosseum</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Colosseum_of_Fools">Colosseum</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_105">
@@ -726,75 +726,75 @@
 			    <span>Trial of the Fool</span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Dreamers">Dreamers</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Dreamers">Dreamers</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_108">
 				<input type="checkbox" name="progress" id="item_108" data-key="108" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dreamers#Lurien_the_Watcher">Lurien the Watcher</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dreamers#Lurien_the_Watcher">Lurien the Watcher</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_109">
 				<input type="checkbox" name="progress" id="item_109" data-key="109" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dreamers#Monomon_the_Teacher">Monomon the Teacher</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dreamers#Monomon_the_Teacher">Monomon the Teacher</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_110">
 				<input type="checkbox" name="progress" id="item_110" data-key="110" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Dreamers#Herrah_the_Beast">Herrah the Beast</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Dreamers#Herrah_the_Beast">Herrah the Beast</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_111">
 				<input type="checkbox" name="progress" id="item_111" data-key="111" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Galien">Galien</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Galien">Galien</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_112">
 				<input type="checkbox" name="progress" id="item_112" data-key="112" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Marmu">Marmu</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Marmu">Marmu</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_113">
 				<input type="checkbox" name="progress" id="item_113" data-key="113" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Markoth">Markoth</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Markoth">Markoth</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_114">
 				<input type="checkbox" name="progress" id="item_114" data-key="114" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Xero">Xero</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Xero">Xero</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_115">
 				<input type="checkbox" name="progress" id="item_115" data-key="115" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/No_Eyes">No Eyes</a></span>
+			    <span><a href="https://hollowknight.wiki/w/No_Eyes">No Eyes</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_116">
 				<input type="checkbox" name="progress" id="item_116" data-key="116" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Elder_Hu">Elder Hu</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Elder_Hu">Elder Hu</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_117">
 				<input type="checkbox" name="progress" id="item_117" data-key="117" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Gorb">Gorb</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Gorb">Gorb</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_118">
 				<input type="checkbox" name="progress" id="item_118" data-key="118" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Nightmare_King_Grimm">Nightmare King Grimm</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Nightmare_King_Grimm">Nightmare King Grimm</a></span>
 			</label>
 		</li>
-	</ul>				<h2><a href="https://hollowknight.fandom.com/wiki/Godhome">Godhome</a></h2>
+	</ul>				<h2><a href="https://hollowknight.wiki/w/Godhome">Godhome</a></h2>
 <ul>
 			<li>
 			<label class="checkboxLabel" for="item_119">
@@ -805,25 +805,25 @@
 			<li>
 			<label class="checkboxLabel" for="item_120">
 				<input type="checkbox" name="progress" id="item_120" data-key="120" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Pantheon_of_the_Master">Pantheon of the Master</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Pantheon_of_the_Master">Pantheon of the Master</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_121">
 				<input type="checkbox" name="progress" id="item_121" data-key="121" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Pantheon_of_the_Artist">Pantheon of the Artist</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Pantheon_of_the_Artist">Pantheon of the Artist</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_122">
 				<input type="checkbox" name="progress" id="item_122" data-key="122" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Pantheon_of_the_Sage">Pantheon of the Sage</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Pantheon_of_the_Sage">Pantheon of the Sage</a></span>
 			</label>
 		</li>
 			<li>
 			<label class="checkboxLabel" for="item_123">
 				<input type="checkbox" name="progress" id="item_123" data-key="123" data-percent="1">
-			    <span><a href="https://hollowknight.fandom.com/wiki/Pantheon_of_the_Knight">Pantheon of the Knight</a></span>
+			    <span><a href="https://hollowknight.wiki/w/Pantheon_of_the_Knight">Pantheon of the Knight</a></span>
 			</label>
 		</li>
 	</ul>			</div>
@@ -834,7 +834,7 @@
 		<p>This is an open-source project, <a href="https://github.com/nebulatron/hollow-knight-checklist">view the code on GitHub</a>.</p>
 		<br>
 		<p>Built and maintained by <a href="https://www.reddit.com/user/nebulatron">nebulatron</a> with data sourced from <a href="https://www.reddit.com/user/nebulatron">arson_cat</a>'s <a href="https://www.reddit.com/r/HollowKnight/comments/9a9es4/printable_completion_checklist_updated_and/">Printable Completion Checklist</a>.</p>
-		<p>Graphics sourced from <a href="https://www.vecteezy.com/free-vector/art-nouveau">Art Nouveau Vector by Vecteezy</a>, <a href="http://subtlepatterns.com">subtlepatterns.com</a>, and the <a href="https://hollowknight.fandom.com/wiki/Hollow_Knight_Wiki">Fandom Wiki</a>.</p>
+		<p>Graphics sourced from <a href="https://www.vecteezy.com/free-vector/art-nouveau">Art Nouveau Vector by Vecteezy</a>, <a href="http://subtlepatterns.com">subtlepatterns.com</a>, and the <a href="https://hollowknight.wiki/w/Hollow_Knight_Wiki">Fandom Wiki</a>.</p>
 		<p>Much thanks to our testers, <a href="https://www.reddit.com/user/lebdrift">lebdrift</a>, <a href="https://twitter.com/Lukkke6">Lukkke6</a>, <a href="https://steamcommunity.com/profiles/76561198147270936">MrKingless</a>, <a href="http://steamcommunity.com/profiles/76561198060332902">NyappyCat</a>, and <a href="https://steamcommunity.com/profiles/76561197969566579">sheaduran</a>.</p>
 		<br>
 		<p>This is a fan project; we are not affiliated with <a href="https://teamcherry.com.au/">Team Cherry</a>.</p>

--- a/gameData.json
+++ b/gameData.json
@@ -2,151 +2,151 @@
 	"bosses": {
 		"broken_vessel": {
 			"id": 1,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Broken_Vessel\">Broken Vessel</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Broken_Vessel\">Broken Vessel</a>",
 			"percent": 1
 		},
 		"brooding_mawlek": {
 			"id": 2,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Brooding_Mawlek\">Brooding Mawlek</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Brooding_Mawlek\">Brooding Mawlek</a>",
 			"percent": 1
 		},
 		"the_collector": {
 			"id": 3,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Collector\">The Collector</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Collector\">The Collector</a>",
 			"percent": 1
 		},
 		"dung_defender": {
 			"id": 4,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dung_Defender\">Dung Defender</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dung_Defender\">Dung Defender</a>",
 			"percent": 1
 		},
 		"false_knight": {
 			"id": 5,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/False_Knight\">False Knight</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/False_Knight\">False Knight</a>",
 			"percent": 1
 		},
 		"grimm": {
 			"id": 6,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Grimm\">Grimm</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Grimm\">Grimm</a>",
 			"percent": 1
 		},
 		"gruz_mother": {
 			"id": 7,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Gruz_Mother\">Gruz Mother</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Gruz_Mother\">Gruz Mother</a>",
 			"percent": 1
 		},
 		"hive_knight": {
 			"id": 8,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Hive_Knight\">Hive Knight</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Hive_Knight\">Hive Knight</a>",
 			"percent": 1
 		},
 		"hornet_greenpath": {
 			"id": 9,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Hornet_Protector\">Hornet (Greenpath)</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Hornet_Protector\">Hornet (Greenpath)</a>",
 			"percent": 1
 		},
 		"hornet_cast_off_shell": {
 			"id": 10,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Hornet_Sentinel\">Hornet (Cast-Off Shell)</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Hornet_Sentinel\">Hornet (Cast-Off Shell)</a>",
 			"percent": 1
 		},
 		"mantis_lords": {
 			"id": 11,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Mantis_Lords\">Mantis Lords</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Mantis_Lords\">Mantis Lords</a>",
 			"percent": 1
 		},
 		"nosk": {
 			"id": 12,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Nosk\">Nosk</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Nosk\">Nosk</a>",
 			"percent": 1
 		},
 		"soul_master": {
 			"id": 13,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Soul_Master\">Soul Master</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Soul_Master\">Soul Master</a>",
 			"percent": 1
 		},
 		"traitor_lord": {
 			"id": 14,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Traitor_Lord\">Traitor Lord</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Traitor_Lord\">Traitor Lord</a>",
 			"percent": 1
 		},
 		"uumuu": {
 			"id": 15,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Uumuu\">Uumuu</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Uumuu\">Uumuu</a>",
 			"percent": 1
 		},
 		"watcher_knight": {
 			"id": 16,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Watcher_Knight\">Watcher Knight</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Watcher_Knight\">Watcher Knight</a>",
 			"percent": 1
 		}
 	},
 	"equipment": {
 		"mothwing_cloak": {
 			"id": 17,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Mothwing_Cloak\">Mothwing Cloak</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Mothwing_Cloak\">Mothwing Cloak</a>",
 			"percent": 2
 		},
 		"mantis_claw": {
 			"id": 18,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Mantis_Claw\">Mantis Claw</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Mantis_Claw\">Mantis Claw</a>",
 			"percent": 2
 		},
 		"crystal_heart": {
 			"id": 19,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Crystal_Heart\">Crystal Heart</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Crystal_Heart\">Crystal Heart</a>",
 			"percent": 2
 		},
 		"isma_s_tear": {
 			"id": 20,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Isma's_Tear\">Isma's Tear</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Isma's_Tear\">Isma's Tear</a>",
 			"percent": 2
 		},
 		"king_s_brand": {
 			"id": 21,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/King's_Brand\">King's Brand</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/King's_Brand\">King's Brand</a>",
 			"percent": 2
 		},
 		"monarch_wings": {
 			"id": 22,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Monarch_Wings\">Monarch Wings</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Monarch_Wings\">Monarch Wings</a>",
 			"percent": 2
 		},
 		"shade_cloak": {
 			"id": 23,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Shade_Cloak\">Shade Cloak</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Shade_Cloak\">Shade Cloak</a>",
 			"percent": 2
 		}
 	},
 	"spells": {
 		"vengeful_spirit": {
 			"id": 24,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Vengeful_Spirit\">Vengeful Spirit</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Vengeful_Spirit\">Vengeful Spirit</a>",
 			"percent": 1
 		},
 		"shade_soul": {
 			"id": 25,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Shade_Soul\">Shade Soul</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Shade_Soul\">Shade Soul</a>",
 			"percent": 1
 		},
 		"desolate_dive": {
 			"id": 26,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Desolate_Dive\">Desolate Dive</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Desolate_Dive\">Desolate Dive</a>",
 			"percent": 1
 		},
 		"descending_dark": {
 			"id": 27,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Descending_Dark\">Descending Dark</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Descending_Dark\">Descending Dark</a>",
 			"percent": 1
 		},
 		"howling_wraiths": {
 			"id": 28,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Howling_Wraiths\">Howling Wraiths</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Howling_Wraiths\">Howling Wraiths</a>",
 			"percent": 1
 		},
 		"abyss_shriek": {
 			"id": 29,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Abyss_Shriek\">Abyss Shriek</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Abyss_Shriek\">Abyss Shriek</a>",
 			"percent": 1
 		}
 	},
@@ -192,19 +192,19 @@
 	"nail_arts": {
 		"great_slash": {
 			"id": 37,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Great_Slash\">Great Slash</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Great_Slash\">Great Slash</a>",
 			"source": "Nailmaster Sheo",
 			"percent": 1
 		},
 		"dash_slash": {
 			"id": 38,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dash_Slash\">Dash Slash</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dash_Slash\">Dash Slash</a>",
 			"source": "Nailmaster Oro",
 			"percent": 1
 		},
 		"cyclone_slash": {
 			"id": 39,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Cyclone_Slash\">Cyclone Slash</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Cyclone_Slash\">Cyclone Slash</a>",
 			"source": "Nailmaster Mato",
 			"percent": 1
 		}
@@ -212,370 +212,370 @@
 	"vessel_fragments": [
 		{
 			"id": 40,
-			"description": "Bought from <a href=\"https://hollowknight.fandom.com/wiki/Sly\">Sly</a> in Dirtmouth for [geo]550",
+			"description": "Bought from <a href=\"https://hollowknight.wiki/w/Sly\">Sly</a> in Dirtmouth for [geo]550",
 			"percent": 0.3333333
 		},
 		{
 			"id": 41,
-			"description": "Bought from <a href=\"https://hollowknight.fandom.com/wiki/Sly\">Sly</a> in Dirtmouth for [geo]900",
+			"description": "Bought from <a href=\"https://hollowknight.wiki/w/Sly\">Sly</a> in Dirtmouth for [geo]900",
 			"percent": 0.3333333
 		},
 		{
 			"id": 42,
-			"description": "Found in <a href=\"https://hollowknight.fandom.com/wiki/Greenpath\">Greenpath</a> near the inaccessible <a href=\"https://hollowknight.fandom.com/wiki/Queen%27s_Gardens\">Queen's Gardens</a> entrance",
+			"description": "Found in <a href=\"https://hollowknight.wiki/w/Greenpath\">Greenpath</a> near the inaccessible <a href=\"https://hollowknight.wiki/w/Queen%27s_Gardens\">Queen's Gardens</a> entrance",
 			"percent": 0.3333333
 		},
 		{
 			"id": 43,
-			"description": "Left of the lift in <a href=\"https://hollowknight.fandom.com/wiki/Forgotten_Crossroads\">Forgotten Crossroads</a>",
+			"description": "Left of the lift in <a href=\"https://hollowknight.wiki/w/Forgotten_Crossroads\">Forgotten Crossroads</a>",
 			"percent": 0.3333333
 		},
 		{
 			"id": 44,
-			"description": "Found above <a href=\"https://hollowknight.fandom.com/wiki/City_of_Tears#Sub-area:_King.27s_Station\">King's Station</a> near a lift",
+			"description": "Found above <a href=\"https://hollowknight.wiki/w/City_of_Tears#Sub-area:_King.27s_Station\">King's Station</a> near a lift",
 			"percent": 0.3333333
 		},
 		{
 			"id": 45,
-			"description": "Found in <a href=\"https://hollowknight.fandom.com/wiki/Deepnest\">Deepnest</a> above the working tram",
+			"description": "Found in <a href=\"https://hollowknight.wiki/w/Deepnest\">Deepnest</a> above the working tram",
 			"percent": 0.3333333
 		},
 		{
 			"id": 46,
-			"description": "Found at the end of <a href=\"https://hollowknight.fandom.com/wiki/Howling_Cliffs#Sub-area:_Stag_Nest\">Stag Nest</a>",
+			"description": "Found at the end of <a href=\"https://hollowknight.wiki/w/Howling_Cliffs#Sub-area:_Stag_Nest\">Stag Nest</a>",
 			"percent": 0.3333333
 		},
 		{
 			"id": 47,
-			"description": "Given by the <a href=\"https://hollowknight.fandom.com/wiki/Seer\">Seer</a> for [essence]700",
+			"description": "Given by the <a href=\"https://hollowknight.wiki/w/Seer\">Seer</a> for [essence]700",
 			"percent": 0.3333333
 		},
 		{
 			"id": 48,
-			"description": "Found in the fountain in <a href=\"https://hollowknight.fandom.com/wiki/Ancient_Basin\">Ancient Basin</a> for [geo]3000",
+			"description": "Found in the fountain in <a href=\"https://hollowknight.wiki/w/Ancient_Basin\">Ancient Basin</a> for [geo]3000",
 			"percent": 0.3333333
 		}
 	],
 	"mask_shards": [
 		{
 			"id": 49,
-			"description": "Bought from <a href=\"https://hollowknight.fandom.com/wiki/Sly\">Sly</a> in Dirtmouth for [geo]150",
+			"description": "Bought from <a href=\"https://hollowknight.wiki/w/Sly\">Sly</a> in Dirtmouth for [geo]150",
 			"percent": 0.25
 		},
 		{
 			"id": 50,
-			"description": "Bought from <a href=\"https://hollowknight.fandom.com/wiki/Sly\">Sly</a> in Dirtmouth for [geo]500",
+			"description": "Bought from <a href=\"https://hollowknight.wiki/w/Sly\">Sly</a> in Dirtmouth for [geo]500",
 			"percent": 0.25
 		},
 		{
 			"id": 51,
-			"description": "Bought from <a href=\"https://hollowknight.fandom.com/wiki/Sly\">Sly</a> in Dirtmouth for [geo]800",
+			"description": "Bought from <a href=\"https://hollowknight.wiki/w/Sly\">Sly</a> in Dirtmouth for [geo]800",
 			"percent": 0.25
 		},
 		{
 			"id": 52,
-			"description": "Bought from <a href=\"https://hollowknight.fandom.com/wiki/Sly\">Sly</a> in Dirtmouth for [geo]1500",
+			"description": "Bought from <a href=\"https://hollowknight.wiki/w/Sly\">Sly</a> in Dirtmouth for [geo]1500",
 			"percent": 0.25
 		},
 		{
 			"id": 53,
-			"description": "Defeating <a href=\"https://hollowknight.fandom.com/wiki/Brooding_Mawlek\">Brooding Mawleck</a> far West of the <a href=\"https://hollowknight.fandom.com/wiki/Forgotten_Crossroads\">Forgotten Crossroads</a>",
+			"description": "Defeating <a href=\"https://hollowknight.wiki/w/Brooding_Mawlek\">Brooding Mawleck</a> far West of the <a href=\"https://hollowknight.wiki/w/Forgotten_Crossroads\">Forgotten Crossroads</a>",
 			"percent": 0.25
 		},
 		{
 			"id": 54,
-			"description": "Given by <a href=\"https://hollowknight.fandom.com/wiki/Grubfather\">Grubfather</a> after rescuing 5 grubs",
+			"description": "Given by <a href=\"https://hollowknight.wiki/w/Grubfather\">Grubfather</a> after rescuing 5 grubs",
 			"percent": 0.25
 		},
 		{
 			"id": 55,
-			"description": " <a href=\"https://hollowknight.fandom.com/wiki/Forgotten_Crossroads\">Forgotten Crossroads</a> South of <a href=\"https://hollowknight.fandom.com/wiki/False_Knight\">False Knight</a> (where there are <a href=\"https://hollowknight.fandom.com/wiki/Goam\">Goams</a>)",
+			"description": " <a href=\"https://hollowknight.wiki/w/Forgotten_Crossroads\">Forgotten Crossroads</a> South of <a href=\"https://hollowknight.wiki/w/False_Knight\">False Knight</a> (where there are <a href=\"https://hollowknight.wiki/w/Goam\">Goams</a>)",
 			"percent": 0.25
 		},
 		{
 			"id": 56,
-			"description": "In <a href=\"https://hollowknight.fandom.com/wiki/Fungal_Wastes#Sub-area:_Queen.27s_Station_.C2.A0\">Queen's Station</a>, near East side",
+			"description": "In <a href=\"https://hollowknight.wiki/w/Fungal_Wastes#Sub-area:_Queen.27s_Station_.C2.A0\">Queen's Station</a>, near East side",
 			"percent": 0.25
 		},
 		{
 			"id": 57,
-			"description": "Found in <a href=\"https://hollowknight.fandom.com/wiki/Bretta\">Bretta</a>'s house in Dirtmouth",
+			"description": "Found in <a href=\"https://hollowknight.wiki/w/Bretta\">Bretta</a>'s house in Dirtmouth",
 			"percent": 0.25
 		},
 		{
 			"id": 58,
-			"description": "Found in <a href=\"https://hollowknight.fandom.com/wiki/Greenpath#Sub-area:_Stone_Sanctuary\">Stone Sanctuary</a> in <a href=\"https://hollowknight.fandom.com/wiki/Greenpath\">Greenpath</a>",
+			"description": "Found in <a href=\"https://hollowknight.wiki/w/Greenpath#Sub-area:_Stone_Sanctuary\">Stone Sanctuary</a> in <a href=\"https://hollowknight.wiki/w/Greenpath\">Greenpath</a>",
 			"percent": 0.25
 		},
 		{
 			"id": 59,
-			"description": "<a href=\"https://hollowknight.fandom.com/wiki/Royal_Waterways\">Royal Waterways</a> NW section, swim left under main path",
+			"description": "<a href=\"https://hollowknight.wiki/w/Royal_Waterways\">Royal Waterways</a> NW section, swim left under main path",
 			"percent": 0.25
 		},
 		{
 			"id": 60,
-			"description": "Found in <a href=\"https://hollowknight.fandom.com/wiki/Deepnest\">Deepnest</a> through <a href=\"https://hollowknight.fandom.com/wiki/Fungal_Wastes#Sub-area:_Fungal_Core\">Fungal Core</a>, near <a href=\"https://hollowknight.fandom.com/wiki/Mantis_Lords\">Mantis Lords</a>",
+			"description": "Found in <a href=\"https://hollowknight.wiki/w/Deepnest\">Deepnest</a> through <a href=\"https://hollowknight.wiki/w/Fungal_Wastes#Sub-area:_Fungal_Core\">Fungal Core</a>, near <a href=\"https://hollowknight.wiki/w/Mantis_Lords\">Mantis Lords</a>",
 			"percent": 0.25
 		},
 		{
 			"id": 61,
-			"description": "Reward from <a href=\"https://hollowknight.fandom.com/wiki/Enraged_Guardian\">Enraged Guardian</a>",
+			"description": "Reward from <a href=\"https://hollowknight.wiki/w/Enraged_Guardian\">Enraged Guardian</a>",
 			"percent": 0.25
 		},
 		{
 			"id": 62,
-			"description": "Found behind a wall in <a href=\"https://hollowknight.fandom.com/wiki/Hive\">The Hive</a>",
+			"description": "Found behind a wall in <a href=\"https://hollowknight.wiki/w/Hive\">The Hive</a>",
 			"percent": 0.25
 		},
 		{
 			"id": 63,
-			"description": "Given by the <a href=\"https://hollowknight.fandom.com/wiki/Seer\">Seer</a> for [essence]1500",
+			"description": "Given by the <a href=\"https://hollowknight.wiki/w/Seer\">Seer</a> for [essence]1500",
 			"percent": 0.25
 		},
 		{
 			"id": 64,
-			"description": "Given by <a href=\"https://hollowknight.fandom.com/wiki/Grey_Mourner\">Grey Mourner</a> in <a href=\"https://hollowknight.fandom.com/wiki/Resting_Grounds\">Resting Grounds</a>",
+			"description": "Given by <a href=\"https://hollowknight.wiki/w/Grey_Mourner\">Grey Mourner</a> in <a href=\"https://hollowknight.wiki/w/Resting_Grounds\">Resting Grounds</a>",
 			"percent": 0.25
 		}
 	],
 	"charms": {
 		"wayward_compass": {
 			"id": 65,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Wayward_Compass\">Wayward Compass</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Wayward_Compass\">Wayward Compass</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"gathering_swarm": {
 			"id": 66,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Gathering_Swarm\">Gathering Swarm</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Gathering_Swarm\">Gathering Swarm</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"stalwart_shell": {
 			"id": 67,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Stalwart_Shell\">Stalwart Shell</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Stalwart_Shell\">Stalwart Shell</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"soul_catcher": {
 			"id": 68,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Soul_Catcher\">Soul Catcher</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Soul_Catcher\">Soul Catcher</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"shaman_stone": {
 			"id": 69,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Shaman_Stone\">Shaman Stone</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Shaman_Stone\">Shaman Stone</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"soul_eater": {
 			"id": 70,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Soul_Eater\">Soul Eater</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Soul_Eater\">Soul Eater</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"dashmaster": {
 			"id": 71,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dashmaster\">Dashmaster</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dashmaster\">Dashmaster</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"sprintmaster": {
 			"id": 72,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Sprintmaster\">Sprintmaster</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Sprintmaster\">Sprintmaster</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"grubsong": {
 			"id": 73,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Grubsong\">Grubsong</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Grubsong\">Grubsong</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"grubberfly_s_elegy": {
 			"id": 74,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Grubberfly's_Elegy\">Grubberfly's Elegy</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Grubberfly's_Elegy\">Grubberfly's Elegy</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"fragile_heart": {
 			"id": 75,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Fragile_Heart\">Fragile Heart</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Fragile_Heart\">Fragile Heart</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"fragile_greed": {
 			"id": 76,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Fragile_Greed\">Fragile Greed</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Fragile_Greed\">Fragile Greed</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"fragile_strength": {
 			"id": 77,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Fragile_Strength\">Fragile Strength</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Fragile_Strength\">Fragile Strength</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"spell_twister": {
 			"id": 78,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Spell_Twister\">Spell Twister</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Spell_Twister\">Spell Twister</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"steady_body": {
 			"id": 79,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Steady_Body\">Steady Body</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Steady_Body\">Steady Body</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"heavy_blow": {
 			"id": 80,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Heavy_Blow\">Heavy Blow</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Heavy_Blow\">Heavy Blow</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"quick_slash": {
 			"id": 81,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Quick_Slash\">Quick Slash</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Quick_Slash\">Quick Slash</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"longnail": {
 			"id": 82,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Longnail\">Longnail</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Longnail\">Longnail</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"mark_of_pride": {
 			"id": 83,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Mark_of_Pride\">Mark of Pride</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Mark_of_Pride\">Mark of Pride</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"fury_of_the_fallen": {
 			"id": 84,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Fury_of_the_Fallen\">Fury of the Fallen</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Fury_of_the_Fallen\">Fury of the Fallen</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"thorns_of_agony": {
 			"id": 85,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Thorns_of_Agony\">Thorns of Agony</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Thorns_of_Agony\">Thorns of Agony</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"baldur_shell": {
 			"id": 86,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Baldur_Shell\">Baldur Shell</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Baldur_Shell\">Baldur Shell</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"flukenest": {
 			"id": 87,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Flukenest\">Flukenest</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Flukenest\">Flukenest</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"defender_s_crest": {
 			"id": 88,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Defender's_Crest\">Defender's Crest</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Defender's_Crest\">Defender's Crest</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"glowing_womb": {
 			"id": 89,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Glowing_Womb\">Glowing Womb</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Glowing_Womb\">Glowing Womb</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"quick_focus": {
 			"id": 90,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Quick_Focus\">Quick Focus</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Quick_Focus\">Quick Focus</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"deep_focus": {
 			"id": 91,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Deep_Focus\">Deep Focus</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Deep_Focus\">Deep Focus</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"lifeblood_heart": {
 			"id": 92,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Lifeblood_Heart\">Lifeblood Heart</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Lifeblood_Heart\">Lifeblood Heart</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"lifeblood_core": {
 			"id": 93,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Lifeblood_Core\">Lifeblood Core</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Lifeblood_Core\">Lifeblood Core</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"joni_s_blessing": {
 			"id": 94,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Joni's_Blessing\">Joni's Blessing</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Joni's_Blessing\">Joni's Blessing</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"hiveblood": {
 			"id": 95,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Hiveblood\">Hiveblood</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Hiveblood\">Hiveblood</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"spore_shroom": {
 			"id": 96,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Spore_Shroom\">Spore Shroom</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Spore_Shroom\">Spore Shroom</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"sharp_shadow": {
 			"id": 97,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Sharp_Shadow\">Sharp Shadow</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Sharp_Shadow\">Sharp Shadow</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"shape_of_unn": {
 			"id": 98,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Shape_of_Unn\">Shape of Unn</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Shape_of_Unn\">Shape of Unn</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"nailmaster_s_glory": {
 			"id": 99,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Nailmaster's_Glory\">Nailmaster's Glory</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Nailmaster's_Glory\">Nailmaster's Glory</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"weaversong": {
 			"id": 100,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Weaversong\">Weaversong</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Weaversong\">Weaversong</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"dream_wielder": {
 			"id": 101,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dream_Wielder\">Dream Wielder</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dream_Wielder\">Dream Wielder</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"dreamshield": {
 			"id": 102,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dreamshield\">Dreamshield</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dreamshield\">Dreamshield</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"grimmchild_carefree_melody": {
 			"id": 103,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Grimmchild\">Grimmchild</a> / <a href=\"https://hollowknight.fandom.com/wiki/Carefree_Melody\">Carefree Melody</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Grimmchild\">Grimmchild</a> / <a href=\"https://hollowknight.wiki/w/Carefree_Melody\">Carefree Melody</a>",
 			"icon": "charm.png",
 			"percent": 1
 		},
 		"kingsoul_void_heart": {
 			"id": 104,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Kingsoul\">Kingsoul</a> / <a href=\"https://hollowknight.fandom.com/wiki/Void_Heart\">Void Heart</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Kingsoul\">Kingsoul</a> / <a href=\"https://hollowknight.wiki/w/Void_Heart\">Void Heart</a>",
 			"icon": "charm.png",
 			"percent": 1
 		}
@@ -600,57 +600,57 @@
 	"dreamers": {
 		"lurien_the_watcher": {
 			"id": 108,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dreamers#Lurien_the_Watcher\">Lurien the Watcher</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dreamers#Lurien_the_Watcher\">Lurien the Watcher</a>",
 			"percent": 1
 		},
 		"monomon_the_teacher": {
 			"id": 109,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dreamers#Monomon_the_Teacher\">Monomon the Teacher</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dreamers#Monomon_the_Teacher\">Monomon the Teacher</a>",
 			"percent": 1
 		},
 		"herrah_the_beast": {
 			"id": 110,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Dreamers#Herrah_the_Beast\">Herrah the Beast</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Dreamers#Herrah_the_Beast\">Herrah the Beast</a>",
 			"percent": 1
 		},
 		"galien": {
 			"id": 111,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Galien\">Galien</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Galien\">Galien</a>",
 			"percent": 1
 		},
 		"marmu": {
 			"id": 112,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Marmu\">Marmu</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Marmu\">Marmu</a>",
 			"percent": 1
 		},
 		"markoth": {
 			"id": 113,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Markoth\">Markoth</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Markoth\">Markoth</a>",
 			"percent": 1
 		},
 		"xero": {
 			"id": 114,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Xero\">Xero</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Xero\">Xero</a>",
 			"percent": 1
 		},
 		"no_eyes": {
 			"id": 115,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/No_Eyes\">No Eyes</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/No_Eyes\">No Eyes</a>",
 			"percent": 1
 		},
 		"elder_hu": {
 			"id": 116,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Elder_Hu\">Elder Hu</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Elder_Hu\">Elder Hu</a>",
 			"percent": 1
 		},
 		"gorb": {
 			"id": 117,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Gorb\">Gorb</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Gorb\">Gorb</a>",
 			"percent": 1
 		},
 		"nightmare_king_grimm": {
 			"id": 118,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Nightmare_King_Grimm\">Nightmare King Grimm</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Nightmare_King_Grimm\">Nightmare King Grimm</a>",
 			"percent": 1
 		}
 	},
@@ -662,22 +662,22 @@
 		},
 		"pantheon_of_the_master": {
 			"id": 120,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Pantheon_of_the_Master\">Pantheon of the Master</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Pantheon_of_the_Master\">Pantheon of the Master</a>",
 			"percent": 1
 		},
 		"pantheon_of_the_artist": {
 			"id": 121,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Pantheon_of_the_Artist\">Pantheon of the Artist</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Pantheon_of_the_Artist\">Pantheon of the Artist</a>",
 			"percent": 1
 		},
 		"pantheon_of_the_sage": {
 			"id": 122,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Pantheon_of_the_Sage\">Pantheon of the Sage</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Pantheon_of_the_Sage\">Pantheon of the Sage</a>",
 			"percent": 1
 		},
 		"pantheon_of_the_knight": {
 			"id": 123,
-			"name": "<a href=\"https://hollowknight.fandom.com/wiki/Pantheon_of_the_Knight\">Pantheon of the Knight</a>",
+			"name": "<a href=\"https://hollowknight.wiki/w/Pantheon_of_the_Knight\">Pantheon of the Knight</a>",
 			"percent": 1
 		}
 	}

--- a/twig/index.twig
+++ b/twig/index.twig
@@ -62,20 +62,20 @@
 		</div>
 		<div class="row">
 			<div class="column">
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Category:Bosses_(Hollow_Knight)">Bosses</a>', 'data': bosses, 'idKey': 'boss'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Dream_Nail">Dream Nail</a>', 'data': dream_nail, 'idKey': 'dream_nail'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Nail">Nail</a>', 'data': nail, 'idKey': 'nail'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Category%3ASpells_and_Abilities_(Hollow_Knight)#Nail_Arts">Nail Arts</a>', 'data': nail_arts, 'idKey': 'nail_art'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Category:Charms">Charms</a>', 'data': charms, 'idKey': 'charm'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Category:Bosses_(Hollow_Knight)">Bosses</a>', 'data': bosses, 'idKey': 'boss'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Dream_Nail">Dream Nail</a>', 'data': dream_nail, 'idKey': 'dream_nail'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Nail">Nail</a>', 'data': nail, 'idKey': 'nail'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Category%3ASpells_and_Abilities_(Hollow_Knight)#Nail_Arts">Nail Arts</a>', 'data': nail_arts, 'idKey': 'nail_art'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Category:Charms">Charms</a>', 'data': charms, 'idKey': 'charm'} %}
 			</div>
 			<div class="column">
 				{% include 'common_list.twig' with {'title': 'Equipment', 'data': equipment, 'idKey': 'equipment'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Category:Spells_and_Abilities_(Hollow_Knight)#Spells">Spells</a>', 'data': spells, 'idKey': 'spell'} %}
-				{% include 'description_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Mask_Shard">Mask Shards</a>', 'data': mask_shards, 'idKey': 'mask_shard'} %}
-				{% include 'description_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Vessel_Fragment">Vessel Fragments</a>', 'data': vessel_fragments, 'idKey': 'vessel_fragment'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Colosseum_of_Fools">Colosseum</a>', 'data': colosseum, 'idKey': 'colosseum'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Dreamers">Dreamers</a>', 'data': dreamers, 'idKey': 'dreamer'} %}
-				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.fandom.com/wiki/Godhome">Godhome</a>', 'data': godhome, 'idKey': 'godhome'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Category:Spells_and_Abilities_(Hollow_Knight)#Spells">Spells</a>', 'data': spells, 'idKey': 'spell'} %}
+				{% include 'description_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Mask_Shard">Mask Shards</a>', 'data': mask_shards, 'idKey': 'mask_shard'} %}
+				{% include 'description_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Vessel_Fragment">Vessel Fragments</a>', 'data': vessel_fragments, 'idKey': 'vessel_fragment'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Colosseum_of_Fools">Colosseum</a>', 'data': colosseum, 'idKey': 'colosseum'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Dreamers">Dreamers</a>', 'data': dreamers, 'idKey': 'dreamer'} %}
+				{% include 'common_list.twig' with {'title': '<a href="https://hollowknight.wiki/w/Godhome">Godhome</a>', 'data': godhome, 'idKey': 'godhome'} %}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
I replaced the wiki links with the new independent Hollow Knight Wiki, not the fandom one.

https://old.reddit.com/r/HollowKnight/comments/17kjcde/the_hollow_knight_wiki_has_moved_to/